### PR TITLE
Added Princeton to QURIP Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A list of hands-on opportunites (not jobs) in quantum computing
 ## Internships
 | Name | Link | Organization | Date | Status | Feedback |
 | :--: | :--: | :--: | :--: | :--: | :--: |
-| QURIP | [Info Page](https://www.ibm.com/quantum-computing/internship/qurip/) | IBM | Summer | ![closed status][closed] | [![FB][feedback]](FEEDBACK.md#qurip-ibm) |
+| QURIP | [Info Page](https://www.ibm.com/quantum-computing/internship/qurip/) | IBM and Princeton| Summer | ![closed status][closed] | [![FB][feedback]](FEEDBACK.md#qurip-ibm) |
 | Horizon Summer Internship | [Scroll Down](http://horizonquantum.com/) | Horizon Quantum Computing | Summer | ![open status][open] | [![FB][feedback]](FEEDBACK.md#summer-internship-horizon-quantum-computing) |
 
 ## Research Opportunities


### PR DESCRIPTION
QURIP stands for Quantum Undergraduate Research at IBM and Princeton